### PR TITLE
create the systemd/user directory if not already exists

### DIFF
--- a/auto-enter-pin/installer
+++ b/auto-enter-pin/installer
@@ -9,6 +9,10 @@ wd=$(dirname $(readlink -f $0))
 
 cd $wd
 
+if [ ! -d /home/nemo/.config/systemd/user/ ]
+        then mkdir -p /home/nemo/.config/systemd/user/
+fi
+
 cp *.service /home/nemo/.config/systemd/user/
 
 systemctl --user enable auto-enter-pin.service


### PR DESCRIPTION
nemo@Sailfish:~/auto-enter-pin$ sh installer
cp: cannot create regular file `/home/nemo/.config/systemd/user/': Is a directory
Failed to execute operation: No such file or directory